### PR TITLE
Capacitance Calibration Updates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,16 @@
 # PurpleDrop STM32 Software Releases
 
+## 0.5.1 (2021-06-30)
+
+- Support low gain for active capacitance measurements.
+  - This includes adding a flag for gain setting to active capacitance
+    message, breaking messaging compatibility
+- Increase HV regulator integrator limit
+  - On some boards, this limit prevents the controller from reaching target at
+    higher voltages
+- Add per-electrode capacitance offset calibration
+- Feedback controller uses real capacitance units (pF) instead of count
+
 ## 0.4.1 (2021-04-28)
 
 - Adds feedback control mode for droplet splitting

--- a/src/app/AppConfig.cpp
+++ b/src/app/AppConfig.cpp
@@ -20,6 +20,8 @@ ConfigOptionDescriptor AppConfig::optionDescriptors[] = {
     INTOPT(IntegratorResetDelayId, 1000, "Integrator reset delay", "ns; time between reset release and first sample"),
     BOOLOPT(AugmentTopPlateLowSideId, 0, "Enable Top Plate Augment FET", "Enable extra FET to drive top plate to GND"),
     INTOPT(TopPlatePinId, 97, "Top Plate Pin", "Pin number of HV507 output driving top plate"),
+    FLTOPT(LowGainRId, 33.0, "R Sense Low Gain", "Sense resistance for low gain capacitance measurement"),
+    FLTOPT(HighGainRId, 220.0, "R Sense High Gain", "Sense resistance for high gain capacitance measurement"),
     BOOLOPT(InvertedOptoId, 0, "Inverting Optoisolators", "Invert all opto-isolator IOs to support alternative parts"),
     FLTOPT(FeedbackGainPId, 0.0, "Feedback KP", "Proportional gain for feedback drop control"),
     FLTOPT(FeedbackGainIId, 0.0, "Feedback KI", "Integral gain for feedback drop control"),

--- a/src/app/AppConfig.cpp
+++ b/src/app/AppConfig.cpp
@@ -16,6 +16,7 @@ ConfigOptionDescriptor AppConfig::optionDescriptors[] = {
     INTOPT(ScanBlankDelayId, 4000, "Scan Blank Delay", "ns; delay after asserting blank between each scan measurement"),
     INTOPT(SampleDelayId, 10000, "Sample Delay (high gain)", "ns; Duration of current integration"),
     INTOPT(SampleDelayLowGainId, 40000, "Sample Delay (low gain)", "ns; Duration of current integration"),
+    BOOLOPT(ActiveCapLowGainId, 0, "Active Cap Uses Low Gain", "Use low gain setting to measure active capacitance"),
     INTOPT(BlankingDelayId, 14000, "Active Blank Delay", "ns; delay between blank and integrator reset for active measurement"),
     INTOPT(IntegratorResetDelayId, 1000, "Integrator reset delay", "ns; time between reset release and first sample"),
     BOOLOPT(AugmentTopPlateLowSideId, 0, "Enable Top Plate Augment FET", "Enable extra FET to drive top plate to GND"),

--- a/src/app/AppConfig.hpp
+++ b/src/app/AppConfig.hpp
@@ -18,6 +18,7 @@ enum ConfigOptionIds : uint8_t {
     IntegratorResetDelayId = 25,
     AugmentTopPlateLowSideId = 26,
     SampleDelayLowGainId = 27,
+    ActiveCapLowGainId = 28,
     TopPlatePinId = 30,
     LowGainRId = 31,
     HighGainRId = 32,
@@ -25,8 +26,6 @@ enum ConfigOptionIds : uint8_t {
     FeedbackGainPId = 100,
     FeedbackGainIId = 101,
     FeedbackGainDId = 102
-
-
 };
 
 union ConfigOptionValue {
@@ -59,6 +58,7 @@ struct AppConfig {
     static int32_t BlankingDelay() { return optionValues[BlankingDelayId].i32; }
     static int32_t IntegratorResetDelay() { return optionValues[IntegratorResetDelayId].i32; }
     static bool AugmentTopPlateLowSide() { return (bool)optionValues[AugmentTopPlateLowSideId].i32; }
+    static bool ActiveCapLowGain() { return (bool)optionValues[ActiveCapLowGainId].i32; }
 
     static int32_t TopPlatePin() { return optionValues[TopPlatePinId].i32; }
 

--- a/src/app/AppConfig.hpp
+++ b/src/app/AppConfig.hpp
@@ -19,6 +19,8 @@ enum ConfigOptionIds : uint8_t {
     AugmentTopPlateLowSideId = 26,
     SampleDelayLowGainId = 27,
     TopPlatePinId = 30,
+    LowGainRId = 31,
+    HighGainRId = 32,
     InvertedOptoId = 75,
     FeedbackGainPId = 100,
     FeedbackGainIId = 101,
@@ -59,6 +61,14 @@ struct AppConfig {
     static bool AugmentTopPlateLowSide() { return (bool)optionValues[AugmentTopPlateLowSideId].i32; }
 
     static int32_t TopPlatePin() { return optionValues[TopPlatePinId].i32; }
+
+    // Sense resistor used for low gain capacitance sense setting
+    static float LowGainR() { return optionValues[LowGainRId].f32; }
+    // Sense resistor used for high gain capacitance sense setting
+    static float HighGainR() { return optionValues[HighGainRId].f32; }
+    // Gain of integrator after the sense resistor, with units of V per V-sec.
+    // Used to convert ADC voltage to real capacitance units for convenience
+    static float CapAmplifierGain() {  return 2.0*22.36*25000.0; }
 
     static bool InvertedOpto() { return optionValues[InvertedOptoId].i32 != 0; }
     static float FeedbackKp() { return optionValues[FeedbackGainPId].f32; }

--- a/src/app/Comms.cpp
+++ b/src/app/Comms.cpp
@@ -185,6 +185,7 @@ void Comms::HandleCapActive(CapActive &e) {
     Serializer ser(mTxQueue);
     msg.baseline = e.baseline;
     msg.measurement = e.measurement;
+    msg.settings = e.settings;
     msg.serialize(ser);
     mFlush();
 }

--- a/src/app/Comms.hpp
+++ b/src/app/Comms.hpp
@@ -72,5 +72,5 @@ private:
 
     void PeriodicSend();
     void SendBlob(uint8_t blob_id, const uint8_t *buf, uint32_t size);
-
+    void SendAck(uint8_t acked_id);
 };

--- a/src/app/Events.hpp
+++ b/src/app/Events.hpp
@@ -12,12 +12,16 @@ using namespace EventEx;
 namespace events {
 
 struct CapActive : public Event {
-    CapActive() : CapActive(0, 0) {}
+    CapActive() : CapActive(0, 0, 0) {}
 
-    CapActive(uint16_t _baseline, uint16_t _measurement) : baseline(_baseline), measurement(_measurement) {}
+    CapActive(uint16_t _baseline, uint16_t _measurement, uint8_t _settings) :
+        baseline(_baseline),
+        measurement(_measurement),
+        settings(_settings) {}
 
     uint16_t baseline; // Initial zero level
     uint16_t measurement; // Final voltage value
+    uint8_t settings; // Metadata about the sample; bit 0 indicates low gain.
 };
 
 struct CapOffsetCalibrationRequest : public Event {}; 

--- a/src/app/Events.hpp
+++ b/src/app/Events.hpp
@@ -3,6 +3,7 @@
 #include "AppConfig.hpp"
 
 #include "EventEx.hpp"
+#include "ScanGroups.hpp"
 
 using namespace EventEx;
 
@@ -27,6 +28,7 @@ struct CapScan : public Event {
 
 struct CapGroups : public Event {
     std::array<uint16_t, AppConfig::N_CAP_GROUPS> measurements;
+    ScanGroups<AppConfig::N_PINS, AppConfig::N_CAP_GROUPS> scanGroups;
 };
 
 struct ElectrodesUpdated : public Event {};
@@ -86,6 +88,11 @@ struct FeedbackCommand : public Event {
     uint8_t baseline;
 };
 
+struct HvRegulatorUpdate : public Event {
+    float voltage;
+    uint16_t vTargetOut;
+};
+
 struct SetParameter : public Event {
     uint32_t paramIdx;
     ConfigOptionValue paramValue;
@@ -103,10 +110,12 @@ struct TemperatureMeasurement : public Event {
     uint16_t measurements[AppConfig::N_TEMP_SENSOR];
 };
 
-struct HvRegulatorUpdate : public Event {
-    float voltage;
-    uint16_t vTargetOut;
+// Partial update of the electrode calibration data
+// Calibrations are sent via DataBlob messages, in chunks.
+struct UpdateElectrodeCalibration : public Event {
+    uint16_t offset; // Offset of first byte to update
+    uint16_t length; // Number of bytes to copy
+    const uint8_t *data; // Source data to copy
 };
-
 
 } //namespace events

--- a/src/app/HvRegulator.hpp
+++ b/src/app/HvRegulator.hpp
@@ -13,7 +13,7 @@ static const float VSCALE = (3.3 / 4096.) / VDIVIDER;
 static const uint32_t N_OVERSAMPLE = 12;
 static const float FILTER = 0.25;
 static const float K_INTEGRATOR = 0.3;
-static const float MAX_INTEGRATOR = 250.0;
+static const float MAX_INTEGRATOR = 500.0;
 static const float SLEW_INTEGRATOR = 3;
 // Empirically determined linear relationship between DAC counts and output
 // voltage under nominal load
@@ -45,9 +45,6 @@ struct HvRegulator {
             mVoltageMeasure = mVoltageMeasure * (1 - FILTER) + vcal * FILTER;
             if(AppConfig::HvControlEnabled()) {
                 float target = AppConfig::HvControlTarget();
-                // The differential feedback measurement is offset by reference
-                // diode for conversion to single ended; this is the diode voltage.
-                const float ANALOG_OFFSET = 1.225;
                 float delta = K_INTEGRATOR * (vcal - target);
                 if(delta > SLEW_INTEGRATOR) {
                     delta = SLEW_INTEGRATOR;

--- a/src/app/Messages.hpp
+++ b/src/app/Messages.hpp
@@ -260,7 +260,8 @@ struct SetPwmMsg {
 /** Used to request and return a string of bytes from the purpledrop
  */
 enum DataBlobId : uint16_t {
-    SoftwareVersionBlob = 0
+    SoftwareVersionBlob = 0,
+    OffsetCalibration = 1,
 };
 
 struct DataBlobMsg {

--- a/src/app/Messages.hpp
+++ b/src/app/Messages.hpp
@@ -123,11 +123,13 @@ struct ActiveCapacitanceMsg {
 
     uint16_t baseline;
     uint16_t measurement;
+    uint8_t settings;
 
     void serialize(Serializer &ser) {
         ser.push(ID);
         ser.push(baseline);
         ser.push(measurement);
+        ser.push(settings);
         ser.finish();
     }
 };

--- a/src/app/ScanGroups.hpp
+++ b/src/app/ScanGroups.hpp
@@ -60,6 +60,12 @@ public:
         }
     }
 
+    inline bool isPinActive(uint8_t group, uint8_t pin) {
+        uint8_t byteidx = pin / 8;
+        uint8_t bit = pin % 8;
+        return mGroupMasks[group][byteidx] & (1<<bit);
+    }
+
 private:
     PinMask mGroupMasks[MAX_GROUPS];
     uint8_t mGroupSettings[MAX_GROUPS];


### PR DESCRIPTION
- Support low gain for active capacitance measurements.
  - This includes adding a flag for gain setting to active capacitance
    message, breaking messaging compatibility
- Increase HV regulator integrator limit
  - On some boards, this limit prevents the controller from reaching target at
    higher voltages
- Add per-electrode capacitance offset calibration
- Feedback controller uses real capacitance units (pF) instead of count
